### PR TITLE
Kill any leftover xulrunner processes after tests are done

### DIFF
--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -7,6 +7,8 @@ function finish {
     else
       kill $(jobs -pr)
     fi
+
+    pkill -P 1 -u $(id -u) -n xulrunner # clean up any leftover xulrunner processes from slimerjs
 }
 
 trap finish SIGINT SIGTERM EXIT


### PR DESCRIPTION
`pkill` is set up to only kill processes which are owned by the current user, have a parent PID of 1 (meaning their parent process is no longer running) and it only selects the newest process named `xulrunner`. That should limit the damage the command can cause quite a bit.
